### PR TITLE
I fix docs for distributeETH method.

### DIFF
--- a/pages/flow-of-funds.mdx
+++ b/pages/flow-of-funds.mdx
@@ -16,19 +16,17 @@ Splits may receive funds via two paths:
 
 1. Simply send funds to the Split's address via `send`, `transfer`, or `call`.
    These funds will be flushed to `SplitMain` the next time
-   `distributeETH(address, accounts, percentAllocations, distributorFee, distributorAddress)`
-   is called.
+   [`distributeETH`](/smartcontracts/overview#distributeethaddress) is called.
 1. If the Split is itself a Recipient of another Split, it will receive funds
-   when
-   `distributeETH(address, accounts, percentAllocations, distributorFee, distributorAddress)`
-   is called on the upstream Split.
+   when [`distributeETH`](/smartcontracts/overview#distributeethaddress) is
+   called on the upstream Split.
 
 ### Distributing Funds
 
 Once funds have arrived at `SplitMain`, funds may be distributed by any third
 party willing to pay the gas to call
-`distributeETH(address, accounts, percentAllocations, distributorFee, distributorAddress)`.
-This function only needs to be called once in order for all Recipients to
+[`distributeETH`](/smartcontracts/overview#distributeethaddress). This function
+only needs to be called once in order for all Recipients to
 [withdraw](/core-concepts#withdraw) their share of the
 [balance](/core-concepts#balance). The party who calls this function will
 receive the [Distributor Fee](/core-concepts#distributor-fee) as compensation

--- a/pages/flow-of-funds.mdx
+++ b/pages/flow-of-funds.mdx
@@ -16,15 +16,19 @@ Splits may receive funds via two paths:
 
 1. Simply send funds to the Split's address via `send`, `transfer`, or `call`.
    These funds will be flushed to `SplitMain` the next time
-   `distributeETH(address)` is called.
+   `distributeETH(address, accounts, percentAllocations, distributorFee, distributorAddress)`
+   is called.
 1. If the Split is itself a Recipient of another Split, it will receive funds
-   when `distributeETH(address)` is called on the upstream Split.
+   when
+   `distributeETH(address, accounts, percentAllocations, distributorFee, distributorAddress)`
+   is called on the upstream Split.
 
 ### Distributing Funds
 
 Once funds have arrived at `SplitMain`, funds may be distributed by any third
-party willing to pay the gas to call `distributeETH(address)`. This function
-only needs to be called once in order for all Recipients to
+party willing to pay the gas to call
+`distributeETH(address, accounts, percentAllocations, distributorFee, distributorAddress)`.
+This function only needs to be called once in order for all Recipients to
 [withdraw](/core-concepts#withdraw) their share of the
 [balance](/core-concepts#balance). The party who calls this function will
 receive the [Distributor Fee](/core-concepts#distributor-fee) as compensation
@@ -33,10 +37,10 @@ for paying the gas needed to execute the function.
 ### Withdrawing Funds
 
 Once funds have been distributed, they are now able to be withdrawn by users by
-calling `withdraw(address)`. A user can call this function via the web app,
-or any third party can call this on the account's behalf. This is necessary,
-since Recipients can be smart contracts which can't execute the `withdraw`
-function themselves (they must, however, still be able to receive funds).
+calling `withdraw(address)`. A user can call this function via the web app, or
+any third party can call this on the account's behalf. This is necessary, since
+Recipients can be smart contracts which can't execute the `withdraw` function
+themselves (they must, however, still be able to receive funds).
 
 ### Summary
 

--- a/pages/smartcontracts/overview.mdx
+++ b/pages/smartcontracts/overview.mdx
@@ -45,7 +45,7 @@ can read their audit report
 
 Create a new [`SplitProxy`](#splitproxy)
 
-### `distributeETH(address, accounts, percentAllocations, distributorFee, distributorAddress)`
+### `distributeETH`
 
 Split ETH for Split `address` which allows Recipients to withdraw
 

--- a/pages/smartcontracts/overview.mdx
+++ b/pages/smartcontracts/overview.mdx
@@ -45,7 +45,7 @@ can read their audit report
 
 Create a new [`SplitProxy`](#splitproxy)
 
-### `distributeETH(address)`
+### `distributeETH(address, accounts, percentAllocations, distributorFee, distributorAddress)`
 
 Split ETH for Split `address` which allows Recipients to withdraw
 


### PR DESCRIPTION
- updates parameters mentioned in `distributeETH` method. ✨ 
- invalid info: `distributeETH(address)`. :x:
- updated info: [`distributeETH`](/smartcontracts/overview#distributeethaddress)

Personally, I'd love the ease of just being able to call `distributeETH(address)` unfortunately that method doesn't exist. To prevent misleading other developers, this update is needed.