### PR TITLE
docs: add World Chain and Avalanche to supported networks

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -24,7 +24,7 @@ just want to understand how you can use Splits today, we recommend you check out
 - Free: No protocol fees – runs exactly at gas cost
 - Unstoppable: Non-upgradable contracts run as long as the underlying network
   exists
-- Multichain: Deployed on Ethereum, Optimism, Base, Zora, Polygon, Arbitrum + more
+- Multichain: Deployed on Ethereum, Optimism, Base, Zora, Polygon, Arbitrum, World Chain, Avalanche, and more
 - Open source: All contracts are
   [verified](https://etherscan.io/address/0x2ed6c4b5da6378c7897ac67ba9e43102feb694ee#code),
   [audited](https://github.com/0xSplits/splits-contracts/blob/main/audit/0xSplits_A-1.pdf),


### PR DESCRIPTION
Title: docs: update multichain list in index.mdx

Description:  Updated the index page to explicitly include World Chain and Avalanche in the multichain features list, providing better clarity on protocol deployment.