### PR TITLE
Add missing v2 network deployments to docs

### DIFF
--- a/pages/core/split-v2.mdx
+++ b/pages/core/split-v2.mdx
@@ -265,6 +265,28 @@ Push Splits do **not** work with non-transferable tokens.
 
 </Toggle>
 
+<Toggle title="Abstract – 2741">
+
+| Contract         | Address                                                                                                                      |
+| :--------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| PushSplitFactory | [`0x8E8eB0cC6AE34A38B67D5Cf91ACa38f60bc3Ecf4`](https://abscan.org/address/0x8E8eB0cC6AE34A38B67D5Cf91ACa38f60bc3Ecf4#code) |
+| PushSplit        | [`0x1e2086A7e84a32482ac03000D56925F607CCB708`](https://abscan.org/address/0x1e2086A7e84a32482ac03000D56925F607CCB708#code) |
+| PullSplitFactory | [`0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1`](https://abscan.org/address/0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1#code) |
+| PullSplit        | [`0x98254AeDb6B2c30b70483064367f0BA24ca86244`](https://abscan.org/address/0x98254AeDb6B2c30b70483064367f0BA24ca86244#code) |
+
+</Toggle>
+
+<Toggle title="Avalanche – 43114">
+
+| Contract         | Address                                                                                                                      |
+| :--------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| PushSplitFactory | [`0x8E8eB0cC6AE34A38B67D5Cf91ACa38f60bc3Ecf4`](https://snowscan.xyz/address/0x8E8eB0cC6AE34A38B67D5Cf91ACa38f60bc3Ecf4#code) |
+| PushSplit        | [`0x1e2086A7e84a32482ac03000D56925F607CCB708`](https://snowscan.xyz/address/0x1e2086A7e84a32482ac03000D56925F607CCB708#code) |
+| PullSplitFactory | [`0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1`](https://snowscan.xyz/address/0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1#code) |
+| PullSplit        | [`0x98254AeDb6B2c30b70483064367f0BA24ca86244`](https://snowscan.xyz/address/0x98254AeDb6B2c30b70483064367f0BA24ca86244#code) |
+
+</Toggle>
+
 </Tab>
 
 <Tab>
@@ -376,6 +398,28 @@ Push Splits do **not** work with non-transferable tokens.
 | PushSplit        | [`0x1e2086A7e84a32482ac03000D56925F607CCB708`](https://explore.moderato.tempo.xyz/address/0x1e2086A7e84a32482ac03000D56925F607CCB708) |
 | PullSplitFactory | [`0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1`](https://explore.moderato.tempo.xyz/address/0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1) |
 | PullSplit        | [`0x98254AeDb6B2c30b70483064367f0BA24ca86244`](https://explore.moderato.tempo.xyz/address/0x98254AeDb6B2c30b70483064367f0BA24ca86244) |
+
+</Toggle>
+
+<Toggle title="World Sepolia – 4801">
+
+| Contract         | Address                                                                                                                              |
+| :--------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| PushSplitFactory | [`0x8E8eB0cC6AE34A38B67D5Cf91ACa38f60bc3Ecf4`](https://sepolia.worldscan.org/address/0x8E8eB0cC6AE34A38B67D5Cf91ACa38f60bc3Ecf4#code) |
+| PushSplit        | [`0x1e2086A7e84a32482ac03000D56925F607CCB708`](https://sepolia.worldscan.org/address/0x1e2086A7e84a32482ac03000D56925F607CCB708#code) |
+| PullSplitFactory | [`0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1`](https://sepolia.worldscan.org/address/0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1#code) |
+| PullSplit        | [`0x98254AeDb6B2c30b70483064367f0BA24ca86244`](https://sepolia.worldscan.org/address/0x98254AeDb6B2c30b70483064367f0BA24ca86244#code) |
+
+</Toggle>
+
+<Toggle title="Abstract Sepolia – 11124">
+
+| Contract         | Address                                                                                                                              |
+| :--------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| PushSplitFactory | [`0x8E8eB0cC6AE34A38B67D5Cf91ACa38f60bc3Ecf4`](https://sepolia.abscan.org/address/0x8E8eB0cC6AE34A38B67D5Cf91ACa38f60bc3Ecf4#code) |
+| PushSplit        | [`0x1e2086A7e84a32482ac03000D56925F607CCB708`](https://sepolia.abscan.org/address/0x1e2086A7e84a32482ac03000D56925F607CCB708#code) |
+| PullSplitFactory | [`0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1`](https://sepolia.abscan.org/address/0x6B9118074aB15142d7524E8c4ea8f62A3Bdb98f1#code) |
+| PullSplit        | [`0x98254AeDb6B2c30b70483064367f0BA24ca86244`](https://sepolia.abscan.org/address/0x98254AeDb6B2c30b70483064367f0BA24ca86244#code) |
 
 </Toggle>
 
@@ -509,6 +553,17 @@ USDT on Mainnet is not an ERC20 token, which means it's not compatible with Spli
 
 </Toggle>
 
+<Toggle title="Abstract – 2741">
+
+| Contract         | Address                                                                                                                      |
+| :--------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| PushSplitFactory | [`0xDc6259E13ec0621e6F19026b2e49D846525548Ed`](https://abscan.org/address/0xDc6259E13ec0621e6F19026b2e49D846525548Ed#code) |
+| PushSplit        | [`0x3f81D81e0884abD8Cc4583a704a9397972623214`](https://abscan.org/address/0x3f81D81e0884abD8Cc4583a704a9397972623214#code) |
+| PullSplitFactory | [`0x5cbA88D55Cec83caD5A105Ad40C8c9aF20bE21d1`](https://abscan.org/address/0x5cbA88D55Cec83caD5A105Ad40C8c9aF20bE21d1#code) |
+| PullSplit        | [`0xF9C25250523Df26343222fC46de932355B850c97`](https://abscan.org/address/0xF9C25250523Df26343222fC46de932355B850c97#code) |
+
+</Toggle>
+
 </Tab>
 
 <Tab>
@@ -598,6 +653,28 @@ USDT on Mainnet is not an ERC20 token, which means it's not compatible with Spli
 | PushSplit        | [`0x3f81D81e0884abD8Cc4583a704a9397972623214`](https://www.okx.com/web3/explorer/plumenetwork-dev/address/0x3f81D81e0884abD8Cc4583a704a9397972623214/contract) |
 | PullSplitFactory | [`0x5cbA88D55Cec83caD5A105Ad40C8c9aF20bE21d1`](https://www.okx.com/web3/explorer/plumenetwork-dev/address/0x5cbA88D55Cec83caD5A105Ad40C8c9aF20bE21d1/contract) |
 | PullSplit        | [`0xF9C25250523Df26343222fC46de932355B850c97`](https://www.okx.com/web3/explorer/plumenetwork-dev/address/0xF9C25250523Df26343222fC46de932355B850c97/contract) |
+
+</Toggle>
+
+<Toggle title="World Sepolia – 4801">
+
+| Contract         | Address                                                                                                                              |
+| :--------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| PushSplitFactory | [`0xDc6259E13ec0621e6F19026b2e49D846525548Ed`](https://sepolia.worldscan.org/address/0xDc6259E13ec0621e6F19026b2e49D846525548Ed#code) |
+| PushSplit        | [`0x3f81D81e0884abD8Cc4583a704a9397972623214`](https://sepolia.worldscan.org/address/0x3f81D81e0884abD8Cc4583a704a9397972623214#code) |
+| PullSplitFactory | [`0x5cbA88D55Cec83caD5A105Ad40C8c9aF20bE21d1`](https://sepolia.worldscan.org/address/0x5cbA88D55Cec83caD5A105Ad40C8c9aF20bE21d1#code) |
+| PullSplit        | [`0xF9C25250523Df26343222fC46de932355B850c97`](https://sepolia.worldscan.org/address/0xF9C25250523Df26343222fC46de932355B850c97#code) |
+
+</Toggle>
+
+<Toggle title="Abstract Sepolia – 11124">
+
+| Contract         | Address                                                                                                                              |
+| :--------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| PushSplitFactory | [`0xDc6259E13ec0621e6F19026b2e49D846525548Ed`](https://sepolia.abscan.org/address/0xDc6259E13ec0621e6F19026b2e49D846525548Ed#code) |
+| PushSplit        | [`0x3f81D81e0884abD8Cc4583a704a9397972623214`](https://sepolia.abscan.org/address/0x3f81D81e0884abD8Cc4583a704a9397972623214#code) |
+| PullSplitFactory | [`0x5cbA88D55Cec83caD5A105Ad40C8c9aF20bE21d1`](https://sepolia.abscan.org/address/0x5cbA88D55Cec83caD5A105Ad40C8c9aF20bE21d1#code) |
+| PullSplit        | [`0xF9C25250523Df26343222fC46de932355B850c97`](https://sepolia.abscan.org/address/0xF9C25250523Df26343222fC46de932355B850c97#code) |
 
 </Toggle>
 

--- a/pages/core/warehouse.mdx
+++ b/pages/core/warehouse.mdx
@@ -141,6 +141,30 @@ Any user earning from the Splits ecosystem can access their assets directly from
 
 </Toggle>
 
+<Toggle title="Plume – 98866">
+
+| Contract  | Address                                                                                                                                       |
+| :-------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
+| Warehouse | [`0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8`](https://explorer.plume.org/address/0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8?tab=contract) |
+
+</Toggle>
+
+<Toggle title="Abstract – 2741">
+
+| Contract  | Address                                                                                                                      |
+| :-------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| Warehouse | [`0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8`](https://abscan.org/address/0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8#code) |
+
+</Toggle>
+
+<Toggle title="Avalanche – 43114">
+
+| Contract  | Address                                                                                                                      |
+| :-------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| Warehouse | [`0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8`](https://snowscan.xyz/address/0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8#code) |
+
+</Toggle>
+
 </Tab>
 
 <Tab>
@@ -222,6 +246,30 @@ Any user earning from the Splits ecosystem can access their assets directly from
 | Contract  | Address                                                                                                                                       |
 | :-------- | :-------------------------------------------------------------------------------------------------------------------------------------------- |
 | Warehouse | [`0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8`](https://explore.moderato.tempo.xyz/address/0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8) |
+
+</Toggle>
+
+<Toggle title="Plume Sepolia – 98867">
+
+| Contract  | Address                                                                                                                              |
+| :-------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| Warehouse | [`0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8`](https://testnet-explorer.plume.org/address/0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8?tab=contract) |
+
+</Toggle>
+
+<Toggle title="World Sepolia – 4801">
+
+| Contract  | Address                                                                                                                              |
+| :-------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| Warehouse | [`0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8`](https://sepolia.worldscan.org/address/0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8#code) |
+
+</Toggle>
+
+<Toggle title="Abstract Sepolia – 11124">
+
+| Contract  | Address                                                                                                                              |
+| :-------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| Warehouse | [`0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8`](https://sepolia.abscan.org/address/0x8fb66F38cF86A3d5e8768f8F1754A24A6c661Fb8#code) |
 
 </Toggle>
 


### PR DESCRIPTION
## Summary

Adds missing network deployments to both `split-v2.mdx` and `warehouse.mdx`.

### split-v2.mdx
- **V2.2 Mainnets:** Abstract (2741), Avalanche (43114)
- **V2.2 Testnets:** World Sepolia (4801), Abstract Sepolia (11124)
- **V2.1 Mainnets:** Abstract (2741)
- **V2.1 Testnets:** World Sepolia (4801), Abstract Sepolia (11124)

### warehouse.mdx
- **Mainnets:** Plume (98866), Abstract (2741), Avalanche (43114)
- **Testnets:** Plume Sepolia (98867), World Sepolia (4801), Abstract Sepolia (11124)

All networks have deployments in `splits-contracts-monorepo/packages/splits-v2/deployments/` but were missing from the docs.

## Test plan
- [ ] Verify block explorer links resolve correctly for each new network
- [ ] Confirm contract addresses match deployment JSONs
- [ ] Check pages render correctly with the new Toggle entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)