### PR TITLE
PE-7793: link sweep app.splits.org → explorer.splits.org

### DIFF
--- a/pages/core/split-v2.mdx
+++ b/pages/core/split-v2.mdx
@@ -11,7 +11,7 @@ SplitV2 keeps the original vision of [SplitV1](./split.mdx) while decoupling the
 underlying splitter implementation from where the distributed funds are held (previously `SplitMain`, now [Warehouse](./warehouse)). This decoupling allows us to build different types of splitters with different trade-offs for different use cases.
 At launch, we are offering "Push" and "Pull" splitters.
 
-- Create at [split.new](https://app.splits.org/new/split/)
+- Create at [split.new](https://explorer.splits.org/new/split/)
 - [Github](https://github.com/0xSplits/splits-contracts-monorepo/tree/main/packages/splits-v2)
 - [Contracts & Natspec](https://github.com/0xSplits/splits-contracts-monorepo/tree/main/packages/splits-v2/src/splitters)
 - [SDK](/sdk/splits-v2)

--- a/pages/core/split.mdx
+++ b/pages/core/split.mdx
@@ -10,11 +10,11 @@ value_ each recipient will earn. It's a payable smart contract that distributes
 all ETH & ERC20 tokens it receives among recipients according to pre-set
 ownership percentages.
 
-- Create at [split.new](https://app.splits.org/new/split/)
+- Create at [split.new](https://explorer.splits.org/new/split/)
 - [Github](https://github.com/0xSplits/splits-contracts)
 - [Contracts & Natspec](https://github.com/0xSplits/splits-contracts/tree/main/contracts)
 - [SDK](/sdk/splits-v1)
-- [Example](https://app.splits.org/accounts/0xF8843981e7846945960f53243cA2Fd42a579f719/)
+- [Example](https://explorer.splits.org/accounts/0xF8843981e7846945960f53243cA2Fd42a579f719/)
 - [Audit](https://github.com/0xSplits/splits-contracts/blob/main/audit/0xSplits_A-1.pdf)
 
 ## How it works

--- a/pages/core/swapper.mdx
+++ b/pages/core/swapper.mdx
@@ -18,7 +18,7 @@ the former is enabled for some token-pairs by our UI).
   aren't supported by their oracle. Be very careful when using immutable Swappers!
 </Callout>
 
-- Create at [swapper.new](https://app.splits.org/new/swapper/)
+- Create at [swapper.new](https://explorer.splits.org/new/swapper/)
 - [Github](https://github.com/0xSplits/splits-swapper)
 - [Contracts & Natspec](https://github.com/0xSplits/splits-swapper/tree/main/src)
 - Related: [Oracle](/core/oracle), [Diversifier](/templates/diversifier)

--- a/pages/core/vesting.mdx
+++ b/pages/core/vesting.mdx
@@ -12,7 +12,7 @@ each stream may begin vesting or release tokens independently.
 - [Contracts & NatSpec](https://github.com/0xSplits/splits-vesting/tree/master/src)
 - [Github](https://github.com/0xSplits/splits-vesting)
 - [SDK](/sdk/vesting)
-- [Example](https://app.splits.org/accounts/0xF29Ff96aaEa6C9A1fBa851f74737f3c069d4f1a9/)
+- [Example](https://explorer.splits.org/accounts/0xF29Ff96aaEa6C9A1fBa851f74737f3c069d4f1a9/)
 
 ## How It Works
 

--- a/pages/core/waterfall.mdx
+++ b/pages/core/waterfall.mdx
@@ -10,11 +10,11 @@ distributions occur. It's useful when you want to pay one recipient a specific
 amount _before_ paying another recipient. Just like a Split, a Waterfall is a
 payable smart contract that is composable on both inflow and outflow.
 
-- Create at [waterfall.new](https://app.splits.org/new/waterfall/)
+- Create at [waterfall.new](https://explorer.splits.org/new/waterfall/)
 - [Contracts & Natspec](https://github.com/0xSplits/splits-waterfall/tree/master/src)
 - [Github](https://github.com/0xSplits/splits-waterfall)
 - [SDK](/sdk/waterfall)
-- [Example](https://app.splits.org/accounts/0x3511373c3C78cD04C86c87628238435D7F3E6C4f/)
+- [Example](https://explorer.splits.org/accounts/0x3511373c3C78cD04C86c87628238435D7F3E6C4f/)
 
 ## How It Works
 

--- a/pages/react.mdx
+++ b/pages/react.mdx
@@ -128,7 +128,7 @@ const args = {
   // other chain for non EOAs (e.g. Gnosis Safe's)
   ensPublicClient, // viem public client (optional)
   apiConfig: {
-    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at app.splits.org/settings.
+    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at explorer.splits.org/settings.
   }, // Splits GraphQL API key config, this is required for the data client to access the splits graphQL API.
 }
 

--- a/pages/sdk.mdx
+++ b/pages/sdk.mdx
@@ -39,5 +39,5 @@ If you are migrating to v4, please see the
 ## Subgraph Data
 
 Following the [sunset](https://thegraph.com/blog/sunbeam-upgrade-window/) of the hosted service and the release of v4 SDK we recommend everyone to use our SDK to access any data from the subgraph.
-You can create an API key by signing up on our app, and accessing your [account settings](https://app.splits.org/settings).
+You can create an API key by signing up on our app, and accessing your [account settings](https://explorer.splits.org/settings).
 If you think the SDK does not meet your requirements please reach out to the team and we would be happy to help.

--- a/pages/sdk/data.mdx
+++ b/pages/sdk/data.mdx
@@ -23,7 +23,7 @@ const dataClient = new SplitsClient({
   // other chain for non EOAs (e.g. Gnosis Safe's)
   ensPublicClient, // viem public client (optional)
   apiConfig: {
-    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at app.splits.org/settings.
+    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at explorer.splits.org/settings.
   }, // Splits GraphQL API key config, this is required for the data client to access the splits graphQL API.
 }).dataClient
 ```

--- a/pages/sdk/liquid.mdx
+++ b/pages/sdk/liquid.mdx
@@ -16,7 +16,7 @@ const liquidSplitClient = new LiquidSplitClient({
   // other chain for non EOAs (e.g. Gnosis Safe's)
   ensPublicClient, // viem public client (optional)
   apiConfig: {
-    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at app.splits.org/settings.
+    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at explorer.splits.org/settings.
   }, // Splits GraphQL API key config, this is required for the data client to access the splits graphQL API.
 })
 ```

--- a/pages/sdk/splits-v1.mdx
+++ b/pages/sdk/splits-v1.mdx
@@ -15,7 +15,7 @@ const splitsClient = new SplitsClient({
   // other chain for non EOAs (e.g. Gnosis Safe's)
   ensPublicClient, // viem public client (optional)
   apiConfig: {
-    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at app.splits.org/settings.
+    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at explorer.splits.org/settings.
   }, // Splits GraphQL API key config, this is required for the data client to access the splits graphQL API.
 }).splitV1
 ```

--- a/pages/sdk/splits-v2.mdx
+++ b/pages/sdk/splits-v2.mdx
@@ -15,7 +15,7 @@ const splitsClient = new SplitV2Client({
   // other chain for non EOAs (e.g. Gnosis Safe's)
   ensPublicClient, // viem public client (optional)
   apiConfig: {
-    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at app.splits.org/settings.
+    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at explorer.splits.org/settings.
   }, // Splits GraphQL API key config, this is required for the data client to access the splits graphQL API.
 })
 ```

--- a/pages/sdk/swapper.mdx
+++ b/pages/sdk/swapper.mdx
@@ -16,7 +16,7 @@ const swapperClient = new SwapperClient({
   // other chain for non EOAs (e.g. Gnosis Safe's)
   ensPublicClient, // viem public client (optional)
   apiConfig: {
-    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at app.splits.org/settings.
+    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at explorer.splits.org/settings.
   }, // Splits GraphQL API key config, this is required for the data client to access the splits graphQL API.
 })
 ```

--- a/pages/sdk/vesting.mdx
+++ b/pages/sdk/vesting.mdx
@@ -16,7 +16,7 @@ const vestingClient = new VestingClient({
   // other chain for non EOAs (e.g. Gnosis Safe's)
   ensPublicClient, // viem public client (optional)
   apiConfig: {
-    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at app.splits.org/settings.
+    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at explorer.splits.org/settings.
   }, // Splits GraphQL API key config, this is required for the data client to access the splits graphQL API.
 })
 ```

--- a/pages/sdk/warehouse.mdx
+++ b/pages/sdk/warehouse.mdx
@@ -15,7 +15,7 @@ const warehouseClient = new WarehouseClient({
   // other chain for non EOAs (e.g. Gnosis Safe's)
   ensPublicClient, // viem public client (optional)
   apiConfig: {
-    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at app.splits.org/settings.
+    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at explorer.splits.org/settings.
   }, // Splits GraphQL API key config, this is required for the data client to access the splits graphQL API.
 })
 ```

--- a/pages/sdk/waterfall.mdx
+++ b/pages/sdk/waterfall.mdx
@@ -16,7 +16,7 @@ const waterfallClient = new WaterfallClient({
   // other chain for non EOAs (e.g. Gnosis Safe's)
   ensPublicClient, // viem public client (optional)
   apiConfig: {
-    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at app.splits.org/settings.
+    apiKey: string // You can create an API key by signing up on our app, and accessing your account settings at explorer.splits.org/settings.
   }, // Splits GraphQL API key config, this is required for the data client to access the splits graphQL API.
 })
 ```

--- a/pages/templates/diversifier.mdx
+++ b/pages/templates/diversifier.mdx
@@ -12,7 +12,7 @@ into a stablecoin and set aside for taxes. This template simply stacks a
 [Pass-Through Wallet](/core/pass-through) on top of a [Split](/core/split) on
 top of a number of [Swappers](/core/swapper).
 
-- [Creation form](https://app.splits.org/new/diversifier/)
+- [Creation form](https://explorer.splits.org/new/diversifier/)
 - [Github](https://github.com/0xSplits/splits-diversifier)
 - [Contracts & Natspec](https://github.com/0xSplits/splits-diversifier/tree/main/src)
 - Related: [Split](/core/split), [Swapper](/core/swapper),

--- a/pages/templates/liquid.mdx
+++ b/pages/templates/liquid.mdx
@@ -13,12 +13,12 @@ mutable [Split](/core/split). You can integrate Liquid Splits into your own NFT
 project (including adding your own artwork etc) by forking
 [this repo](https://github.com/0xSplits/splits-liquid-template).
 
-- [Creation form](https://app.splits.org/new/split/?type=liquid)
+- [Creation form](https://explorer.splits.org/new/split/?type=liquid)
 - [Contracts & NatSpec](https://github.com/0xSplits/splits-liquid/tree/master/src)
 - [Github](https://github.com/0xSplits/splits-liquid)
 - [Integration Template](https://github.com/0xSplits/splits-liquid-template)
 - [SDK](/sdk/liquid)
-- [App Example](https://app.splits.org/accounts/0x8427e46826a520b1264B55f31fCB5DDFDc31E349/)
+- [App Example](https://explorer.splits.org/accounts/0x8427e46826a520b1264B55f31fCB5DDFDc31E349/)
 - Related: [Split](/core/split),
   [ERC-1155](https://ethereum.org/en/developers/docs/standards/tokens/erc-1155/)
 

--- a/pages/templates/recoup.mdx
+++ b/pages/templates/recoup.mdx
@@ -9,11 +9,11 @@ The Recoup template allows you to split profits instead of revenue. By creating
 a [Waterfall](/core/waterfall) that points to a number of [Splits](/core/split),
 it makes it easy to repay one group before splitting profits with another.
 
-- [Creation form](https://app.splits.org/new/recoup/)
+- [Creation form](https://explorer.splits.org/new/recoup/)
 - [Contracts & NatSpec](https://github.com/0xSplits/splits-recoup/tree/main/src)
 - [Github](https://github.com/0xSplits/splits-recoup)
 - [SDK](/sdk/templates)
-- [Example](https://app.splits.org/accounts/0x0bb7a1B75Ac3e679d77E5336fDEBcFe95E89cEED/)
+- [Example](https://explorer.splits.org/accounts/0x0bb7a1B75Ac3e679d77E5336fDEBcFe95E89cEED/)
 
 ## How It Works
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -52,4 +52,4 @@ Splits makes it easy to split onchain payments among multiple recipients. Contra
 
 - [GitHub](https://github.com/0xSplits): Source code for all contracts and SDKs
 - [Help Center](https://splits.org/help/): Non-technical user support
-- [App](https://app.splits.org): Web interface for creating and managing splits
+- [App](https://explorer.splits.org): Web interface for creating and managing splits


### PR DESCRIPTION
Part of the Explorer rebrand link sweep — [PE-7793](https://linear.app/splits/issue/PE-7793/link-sweep-appsplitsorg-explorersplitsorg). Paired with the live redirect [PE-7792](https://linear.app/splits/issue/PE-7792/redirect-appsplitsorg-to-explorersplitsorg).

**This is a blanket find-and-replace** of `app.splits.org` → `explorer.splits.org` across every tracked file in the repo. Opened as a **draft** so you can cull anything that shouldn't change.

## What changed (19 files)
All of these are user-facing **protocol-explorer** links (split/swapper/waterfall/etc. creation forms, `/accounts/...` examples), so they're squarely in scope:
- `pages/core/*.mdx`, `pages/templates/*.mdx` — creation forms + account examples
- `public/llms.txt` — the `[App]` link

## 👀 Double-check before merging
The SDK/API-key docs point at `app.splits.org/settings` to get an API key:
- `pages/react.mdx`, `pages/sdk.mdx`, `pages/sdk/*.mdx`

Confirm that **API key / account settings live on the explorer domain** after the rebrand. If API keys stay on `app.splits.org` (Teams), revert those specific lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
