### PR TITLE
Serve docs under /protocol/docs basePath (PE-7785)

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,8 +1,8 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  // Docs are served from splits.org/protocol/docs (PE-7785). next-sitemap
-  // prepends siteUrl to each route path (route paths do NOT include basePath),
-  // so the '/protocol/docs' segment lives on siteUrl here.
+  // Docs are served from splits.org/protocol/docs. next-sitemap prepends
+  // siteUrl to each route path (route paths do NOT include basePath), so the
+  // '/protocol/docs' segment lives on siteUrl here.
   siteUrl:
     process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ?
       'https://splits.org/protocol/docs' :

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,9 +1,12 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
+  // Docs are served from splits.org/protocol/docs (PE-7785). next-sitemap
+  // prepends siteUrl to each route path (route paths do NOT include basePath),
+  // so the '/protocol/docs' segment lives on siteUrl here.
   siteUrl:
     process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ?
-      `https://${process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL}` :
-      `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`,
+      'https://splits.org/protocol/docs' :
+      `https://${process.env.NEXT_PUBLIC_VERCEL_URL}/protocol/docs`,
   generateRobotsTxt: true,
   generateIndexSitemap: false,
   changefreq: 'monthly',

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,10 @@ const withNextra = require('nextra')({
   defaultShowCopyCode: true,
 })
 module.exports = withNextra({
+  // Docs are served from splits.org/protocol/docs via a reverse-proxy rewrite
+  // in the website repo. basePath prefixes every route and asset (incl.
+  // /_next and /api) so they resolve correctly behind that path. See PE-7785.
+  basePath: '/protocol/docs',
   async headers() {
     return [
       {

--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,7 @@ const withNextra = require('nextra')({
 module.exports = withNextra({
   // Docs are served from splits.org/protocol/docs via a reverse-proxy rewrite
   // in the website repo. basePath prefixes every route and asset (incl.
-  // /_next and /api) so they resolve correctly behind that path. See PE-7785.
+  // /_next and /api) so they resolve correctly behind that path.
   basePath: '/protocol/docs',
   async headers() {
     return [

--- a/scripts/generate-llms-full.js
+++ b/scripts/generate-llms-full.js
@@ -48,11 +48,14 @@ function collectPages(dir, prefix) {
   return pages;
 }
 
+// Public canonical base. Docs are served from splits.org/protocol/docs (PE-7785).
+const DOCS_BASE_URL = "https://splits.org/protocol/docs";
+
 // Map file paths to URL paths
 function fileToUrl(relPath) {
   const slug = relPath.replace(/\.mdx$/, "").replace(/\/index$/, "");
-  if (slug === "index") return "https://docs.splits.org";
-  return `https://docs.splits.org/${slug}`;
+  if (slug === "index") return DOCS_BASE_URL;
+  return `${DOCS_BASE_URL}/${slug}`;
 }
 
 // Strip JSX/MDX artifacts and convert to clean markdown
@@ -88,7 +91,7 @@ function main() {
 > Composable, open-source, audited smart contracts for managing onchain revenue. No protocol fees. Runs forever as a hyperstructure.
 
 This file contains the complete protocol documentation concatenated into a single document.
-For a curated index, see https://docs.splits.org/llms.txt
+For a curated index, see ${DOCS_BASE_URL}/llms.txt
 
 ---
 

--- a/scripts/generate-llms-full.js
+++ b/scripts/generate-llms-full.js
@@ -48,7 +48,7 @@ function collectPages(dir, prefix) {
   return pages;
 }
 
-// Public canonical base. Docs are served from splits.org/protocol/docs (PE-7785).
+// Public canonical base. Docs are served from splits.org/protocol/docs.
 const DOCS_BASE_URL = "https://splits.org/protocol/docs";
 
 // Map file paths to URL paths

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -35,7 +35,11 @@ const config: DocsThemeConfig = {
   logo,
   head: function useHead() {
     const { title } = useConfig()
-    const ogImage = `${CLIENT_ORIGIN}/api/og?title=${encodeURIComponent(title)}`
+    // basePath ('/protocol/docs') moves the OG route handler under that prefix,
+    // and OG scrapers need an absolute URL, so include it explicitly.
+    const ogImage = `${CLIENT_ORIGIN}/protocol/docs/api/og?title=${encodeURIComponent(
+      title,
+    )}`
 
     return (
       <>
@@ -81,10 +85,16 @@ const config: DocsThemeConfig = {
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="docs.splits.org" />
-        <meta property="og:site_name" content="docs.splits.org" />
+        <meta property="og:url" content="https://splits.org/protocol/docs" />
+        <meta property="og:site_name" content="splits.org/protocol/docs" />
         <meta name="apple-mobile-web-app-title" content="Protocol" />
-        <link rel="icon" href="/logo_compressed.svg" type="image/svg+xml" />
+        {/* Raw <link> tags are not basePath-prefixed automatically, so the
+            '/protocol/docs' prefix is included explicitly. */}
+        <link
+          rel="icon"
+          href="/protocol/docs/logo_compressed.svg"
+          type="image/svg+xml"
+        />
       </>
     )
   },

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -7,8 +7,9 @@ import { CLIENT_ORIGIN } from './util/requests'
 
 const logo = (
   <>
+    {/* next/image does not prefix basePath here, so include it explicitly. */}
     <Image
-      src="/logo.svg"
+      src="/protocol/docs/logo.svg"
       className="mr-2 rounded-lg"
       alt="splits_logo"
       width={20}


### PR DESCRIPTION
Part of the Teams rebrand (Phase 1a). Moves the protocol docs to be served from `splits.org/protocol/docs` while keeping them in this separate repo/deployment. Pairs with the website-side proxy PR (0xSplits/website, same branch name).

Linear: https://linear.app/splits/issue/PE-7785

## What

- **`next.config.js`** — set Nextra `basePath: '/protocol/docs'`. This prefixes every route plus all `/_next` and `/api` assets, so the app works correctly behind the path when reverse-proxied. Confirmed in the build output (`"basePath":"/protocol/docs"` in `required-server-files.json`).
- **`theme.config.tsx`** — `basePath` moves the App Router OG handler to `/protocol/docs/api/og`, so the absolute OG image URL now includes the prefix; the raw favicon `<link>` (not auto-prefixed) is prefixed explicitly; `og:url`/`og:site_name` updated to the new canonical path.
- **`scripts/generate-llms-full.js`** — `llms-full.txt` canonical URLs now use `splits.org/protocol/docs`.
- **`next-sitemap.config.js`** — `siteUrl` carries the `/protocol/docs` segment so generated sitemap entries use the new canonical path.

## How it fits together

The website (`splits.org`) adds a `beforeFiles` rewrite proxying `/protocol/docs/*` to this deployment's **production Vercel URL**. Because this app sets `basePath`, the proxy preserves the prefix and assets resolve.

## Manual / coordination steps (not in code)

- [ ] Set `DOCS_PROXY_ORIGIN` in the **website** Vercel project to this docs project's production URL.
- [ ] Add a **temporary Vercel redirect** `docs.splits.org` → `https://splits.org/protocol/docs` (kept out of code intentionally; will be removed when `docs.splits.org` is repurposed). Don't point the proxy at `docs.splits.org` or it loops.
- [ ] Deploy order: **this PR first** (so the basePath build is live), then set the env var, then ship the website PR.

## Verify on preview

- [ ] `/protocol/docs` loads with CSS/JS/images (assets under `/protocol/docs/_next`).
- [ ] Internal nav + the `/sdk-info` redirect resolve under the prefix.
- [ ] OG image and favicon load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)