### PR TITLE
PE-6561 Update docs README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,56 @@
-# Getting Started
+# Splits Docs
 
-```
+Documentation for the [Splits](https://splits.org) protocol, SDKs, and developer tools.
+
+The published site lives at [docs.splits.org](https://docs.splits.org). It explains how to use Splits' onchain revenue infrastructure, including payment splits, waterfalls, vesting, swappers, liquid splits, and the TypeScript SDK.
+
+## Contents
+
+- [Protocol introduction](./pages/index.mdx) and [flow of funds](./pages/flow.mdx)
+- [SDK guides](./pages/sdk.mdx) for `@0xsplits/splits-sdk`
+- [React SDK](./pages/react.mdx) and [SplitsKit](./pages/splits-kit.mdx) docs
+- [Core contract docs](./pages/core.mdx)
+- [Template contract docs](./pages/templates.mdx)
+- [`llms.txt`](./public/llms.txt) and generated `llms-full.txt` for AI agents and search tools
+
+## Development
+
+Install dependencies:
+
+```sh
 pnpm install
+```
+
+Start the local docs server:
+
+```sh
 pnpm dev
 ```
 
-Open [http://localhost:3002](http://localhost:3002/).
+Open [http://localhost:3002](http://localhost:3002).
+
+Build the production site:
+
+```sh
+pnpm build
+```
+
+The build generates `public/llms-full.txt`, builds the Nextra site, and generates the sitemap.
+
+## Editing Docs
+
+Most pages are MDX files under [`pages/`](./pages). Navigation labels and ordering are controlled by `_meta.json` files in each section.
+
+When adding or moving content:
+
+- Add the page under the relevant `pages/` section.
+- Update the nearest `_meta.json` so the page appears in the sidebar.
+- Update [`public/llms.txt`](./public/llms.txt) when the new content should be discoverable by AI agents.
+- Keep user-facing product support content in the [Help Center](https://splits.org/help/) unless it belongs in technical protocol or SDK docs.
+
+## Related Repositories
+
+- [splits-contracts-monorepo](https://github.com/0xSplits/splits-contracts-monorepo) for current Splits contracts
+- [splits-sdk](https://github.com/0xSplits/splits-sdk) for TypeScript SDK packages
+- [splits-cli](https://github.com/0xSplits/splits-cli) for the Splits CLI and MCP server
+

--- a/readme.md
+++ b/readme.md
@@ -51,5 +51,6 @@ When adding or moving content:
 ## Related Repositories
 
 - [splits-contracts-monorepo](https://github.com/0xSplits/splits-contracts-monorepo) for current Splits contracts
+- [splits-contracts](https://github.com/0xSplits/splits-contracts) for legacy protocol contracts
 - [splits-sdk](https://github.com/0xSplits/splits-sdk) for TypeScript SDK packages
 

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
-# Splits Docs
+# Splits Protocol Docs
 
-Documentation for the [Splits](https://splits.org) protocol, SDKs, and developer tools.
+Documentation for the [Splits protocol](https://splits.org/protocol/) protocol, SDKs, and developer tools.
 
-The published site lives at [docs.splits.org](https://docs.splits.org). It explains how to use Splits' onchain revenue infrastructure, including payment splits, waterfalls, vesting, swappers, liquid splits, and the TypeScript SDK.
+The published site lives at [splits.org/protocol/docs](https://splits.org/protocol/docs). It explains how to use Splits' onchain revenue infrastructure, including payment splits, waterfalls, vesting, swappers, liquid splits, and the TypeScript SDK.
 
 ## Contents
 
@@ -52,5 +52,4 @@ When adding or moving content:
 
 - [splits-contracts-monorepo](https://github.com/0xSplits/splits-contracts-monorepo) for current Splits contracts
 - [splits-sdk](https://github.com/0xSplits/splits-sdk) for TypeScript SDK packages
-- [splits-cli](https://github.com/0xSplits/splits-cli) for the Splits CLI and MCP server
 


### PR DESCRIPTION
## Summary
- Replace the minimal getting-started README with a descriptive repository README.
- Add repo purpose, docs structure, local development commands, editing guidance, and related Splits repositories.
- Call out `llms.txt` / generated `llms-full.txt` as agent-discoverability surfaces.

## Testing
- `pnpm build` reached a successful Next/Nextra build, then failed because the script calls `yarn post-build` and `yarn` is not installed in this sandbox.
- `pnpm post-build` completed successfully.

Linear: https://linear.app/splits/issue/PE-6561/update-all-public-repos-to-be-descriptive-and-discoverable-by-humans
Prompted by: @gerard